### PR TITLE
Make generator preserve string break for properties

### DIFF
--- a/armaclass/arma_generator.py
+++ b/armaclass/arma_generator.py
@@ -57,7 +57,13 @@ class ArmaGenerator(Generator):
         if name is None:  # We're in an array, we don't have a name. Don't print a newline at the end
             return '"{}"'.format(self._escape_string(data))
 
-        return '{}="{}";\n'.format(name, self._escape_string(data))
+        # Presence of newlines indicates there is at least one string break
+        # Serialization must preserve them
+        if '\n' in data:
+            data_split = [f'"{self._escape_string(string)}"' for string in data.split('\n')]
+            return '{}={};\n'.format(name, ' \\n '.join(data_split))
+        else:
+            return '{}="{}";\n'.format(name, self._escape_string(data))
 
 
 def generate(data, **kwargs):

--- a/tests/test_arma_generator.py
+++ b/tests/test_arma_generator.py
@@ -33,6 +33,7 @@ def _common_test_(python, sqf):
 def test_string_generation(python, sqf):
     _common_test_(python, sqf)
 
+
 @pytest.mark.parametrize('python, sqf', [
     ({'var': 12.3}, 'var=12.3;'),
     ({'var': -12.3}, 'var=-12.3;'),

--- a/tests/test_arma_generator.py
+++ b/tests/test_arma_generator.py
@@ -27,10 +27,11 @@ def _common_test_(python, sqf):
 @pytest.mark.parametrize('python, sqf', [
     ({'var': 'value'}, 'var="value";'),
     ({'var': ['value']}, 'var[]=\n{\n    "value"\n};'),
+    ({'var': 'value1\nvalue2\nvalue3'}, 'var="value1" \\n "value2" \\n "value3";'),
+    ({'var': '"value1"\n"value2"\nvalue3'}, 'var="""value1""" \\n """value2""" \\n "value3";'),
 ])
 def test_string_generation(python, sqf):
     _common_test_(python, sqf)
-
 
 @pytest.mark.parametrize('python, sqf', [
     ({'var': 12.3}, 'var=12.3;'),


### PR DESCRIPTION
Addresses #4 
Extended `generate_string` method for generator and added couple of parameters for string gen test to cover new use case